### PR TITLE
Remove SUMMARY from vCalendar

### DIFF
--- a/tlscal.py
+++ b/tlscal.py
@@ -65,7 +65,6 @@ class WSGIApplication(object):
 
     def create_calendar(self):
         cal = icalendar.Calendar()
-        cal["summary"] = "When do the certs expire?"
         cal["prodid"] = "-//Certficate Expiration//.../"
         cal["version"] = "1.0"
         return cal


### PR DESCRIPTION
The property is not valid for VCALENDAR components, only for VEVENT,
VTODO, VJOURNAL, VALARM: https://tools.ietf.org/html/rfc5545#section-3.8.1.12